### PR TITLE
trailing slash による相対パスのリンク切れを <base> 要素で対応する

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -5,6 +5,7 @@ date: Last Modified
 <html lang="ja">
 
   <head>
+    {% if (env.NODE_ENV === "production") %}<base href="https://covid-19-act.jp/follow/">{% endif %}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Act Against COVID-19 - 医療機関用ツール</title>

--- a/src/index.njk
+++ b/src/index.njk
@@ -73,7 +73,7 @@ date: Last Modified
       <section class="Section -hasSeparator" id="For-what">
         <header class="HeadingAnchor">
           <h2>入口に「入れません」と<br/>表示するポスター</h2>
-          <a href="#For-what"><span class="VisuallyHidden">このセクションへのリンク</a>
+          <a href="#For-what"><span class="VisuallyHidden">このセクションへのリンク</span></a>
         </header>
         <p>熱発症状がみられる方に対して、院内に入ることができない旨と、東京都や日本医師会が設置している相談窓口への電話を促すポスターです。病院の方針として熱発患者を受け入れていたり、感染症外来などを設置している場合は、「入り口から病院の中のスタッフを呼んでもらう」をご活用ください。</p>
         <ul class="ColumnList">

--- a/src/index.njk
+++ b/src/index.njk
@@ -9,7 +9,7 @@ date: Last Modified
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Act Against COVID-19 - 医療機関用ツール</title>
     <script type="text/javascript" src="//webfont.fontplus.jp/accessor/script/fontplus.js?owI8-d2e8Dw%3D&amp;box=wzsij36dhRc%3D&amp;timeout=5&amp;aa=1&amp;ab=2" charset="utf-8"></script>
-    <link rel="stylesheet" href="./style.css">
+    <link rel="stylesheet" href="style.css">
     <meta name="description" content="19が疑われる方についての対応方針を伝えるためのコミュニケーションツールです。あなたの病院の方針に合ったツールを選んでご活用ください。">
     <meta property="og:title" content="Act Against COVID-19 - 医療機関用ツール">
     <meta property="og:type" content="website">
@@ -31,10 +31,10 @@ date: Last Modified
       gtag('js', new Date());
       gtag('config', 'UA-162419995-5');
     </script>
-    <link rel="icon" sizes="any" href="./image/favicon.svg" type="image/svg+xml">
-    <link rel="mask-icon" href="./image/favicon.svg" color="yellow">
-    <link rel="icon alternate" href="./image/favicon.png" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="./image/apple-touch-icon.png">
+    <link rel="icon" sizes="any" href="image/favicon.svg" type="image/svg+xml">
+    <link rel="mask-icon" href="image/favicon.svg" color="yellow">
+    <link rel="icon alternate" href="image/favicon.png" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="image/apple-touch-icon.png">
   </head>
 
   <body>
@@ -78,24 +78,24 @@ date: Last Modified
         <ul class="ColumnList">
           <li>
             <figure class="Poster">
-              <img width="300" height="424" src="./image/preventative-measures-covid-19_1.png" alt="東京都 新型コロナ相談窓口の電話番号が書かれたPreventative Measures COVID-19ポスター" loading="lazy">
+              <img width="300" height="424" src="image/preventative-measures-covid-19_1.png" alt="東京都 新型コロナ相談窓口の電話番号が書かれたPreventative Measures COVID-19ポスター" loading="lazy">
               <figcaption>東京都 新型コロナ相談窓口へ<br>電話してもらう</figcaption>
             </figure>
-            <a class="Btn" href="./document/poster_DontVisit_TKY_en.pdf"><span class="VisuallyHidden">このポスターの</span>A3サイズをダウンロード</a>
+            <a class="Btn" href="document/poster_DontVisit_TKY_en.pdf"><span class="VisuallyHidden">このポスターの</span>A3サイズをダウンロード</a>
           </li>
           <li>
             <figure class="Poster">
-              <img width="300" height="424" src="./image/preventative-measures-covid-19_2.png" alt="日本医師会 新型コロナ相談窓口の電話番号が書かれたPreventative Measures COVID-19ポスター " loading="lazy">
+              <img width="300" height="424" src="image/preventative-measures-covid-19_2.png" alt="日本医師会 新型コロナ相談窓口の電話番号が書かれたPreventative Measures COVID-19ポスター " loading="lazy">
               <figcaption>日本医師会 新型コロナ相談窓口へ<br>電話してもらう</figcaption>
             </figure>
-            <a class="Btn" href="./document/poster_DontVisit_JMA_en.pdf"><span class="VisuallyHidden">このポスターの</span>A3サイズをダウンロード</a>
+            <a class="Btn" href="document/poster_DontVisit_JMA_en.pdf"><span class="VisuallyHidden">このポスターの</span>A3サイズをダウンロード</a>
           </li>
           <li>
             <figure class="Poster">
-              <img width="300" height="424" src="./image/preventative-measures-covid-19_3.png" alt="入り口から病院の中のスタッフを呼んで欲しいと書かれたPreventative Measures COVID-19ポスター " loading="lazy">
+              <img width="300" height="424" src="image/preventative-measures-covid-19_3.png" alt="入り口から病院の中のスタッフを呼んで欲しいと書かれたPreventative Measures COVID-19ポスター " loading="lazy">
               <figcaption>入り口から病院のスタッフを<br>呼んでもらう</figcaption>
             </figure>
-            <a class="Btn" href="./document/poster_DontVisit_CallStaff_en.pdf"><span class="VisuallyHidden">このポスターの</span>A3サイズをダウンロード</a>
+            <a class="Btn" href="document/poster_DontVisit_CallStaff_en.pdf"><span class="VisuallyHidden">このポスターの</span>A3サイズをダウンロード</a>
           </li>
         </ul>
       </section>
@@ -107,60 +107,60 @@ date: Last Modified
         </header>
         <p>COVID-19対策として重要な注意事項が十分に伝わっていない外国人の方々に向けて、その内容を分かりやすく伝えるためのA4フライヤーです。指差しコミュニケーションシートとして、または大きめに印刷してポスターとして院内に貼っていただくなどしてご活用ください。対応言語は随時追加予定です。</p>
         <figure class="Poster">
-          <img width="300" height="424" src="./image/to-foreigners-who-live-in-japan.png" alt="緊急事態宣言に関する注意事項を伝えるフライヤー兼ポスター" loading="lazy">
+          <img width="300" height="424" src="image/to-foreigners-who-live-in-japan.png" alt="緊急事態宣言に関する注意事項を伝えるフライヤー兼ポスター" loading="lazy">
           <figcaption>日本で暮らす外国人のみなさんへ</figcaption>
         </figure>
         <ul class="BtnList">
           <li>
-            <a class="Btn" href="./document/ToForeignersWhoLiveInJapan_English.pdf">英語版<span lang="en">English</span></a>
+            <a class="Btn" href="document/ToForeignersWhoLiveInJapan_English.pdf">英語版<span lang="en">English</span></a>
           </li>
           <li>
-            <span class="Btn -disabled" data-href="./document/ToForeignersWhoLiveInJapan_ZH-Hans.pdf">中国語 簡体字<span lang="en">ZH Hans</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
+            <span class="Btn -disabled" data-href="document/ToForeignersWhoLiveInJapan_ZH-Hans.pdf">中国語 簡体字<span lang="en">ZH Hans</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
           </li>
           <li>
-            <a class="Btn" href="./document/ToForeignersWhoLiveInJapan_Russian.pdf">ロシア語<span lang="en">Russian</span></a>
+            <a class="Btn" href="document/ToForeignersWhoLiveInJapan_Russian.pdf">ロシア語<span lang="en">Russian</span></a>
           </li>
           <li>
-            <a class="Btn" href="./document/ToForeignersWhoLiveInJapan_French.pdf">フランス語<span lang="en">French</span></a>
+            <a class="Btn" href="document/ToForeignersWhoLiveInJapan_French.pdf">フランス語<span lang="en">French</span></a>
           </li>
           <li>
-            <a class="Btn" href="./document/ToForeignersWhoLiveInJapan_Italian.pdf">イタリア語<span lang="en">Italian</span></a>
+            <a class="Btn" href="document/ToForeignersWhoLiveInJapan_Italian.pdf">イタリア語<span lang="en">Italian</span></a>
           </li>
           <li>
-            <span class="Btn -disabled" data-href="./document/ToForeignersWhoLiveInJapan_Spanish.pdf">スペイン語<span lang="en">Spanish</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
+            <span class="Btn -disabled" data-href="document/ToForeignersWhoLiveInJapan_Spanish.pdf">スペイン語<span lang="en">Spanish</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
           </li>
           <li>
-            <a class="Btn" href="./document/ToForeignersWhoLiveInJapan_Portuguese.pdf">ポルトガル語<span lang="en">Portuguese</span></a>
+            <a class="Btn" href="document/ToForeignersWhoLiveInJapan_Portuguese.pdf">ポルトガル語<span lang="en">Portuguese</span></a>
           </li>
           <li>
-            <span class="Btn -disabled" data-href="./document/ToForeignersWhoLiveInJapan_Arabic.pdf">アラビア語<span lang="en">Arabic</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
+            <span class="Btn -disabled" data-href="document/ToForeignersWhoLiveInJapan_Arabic.pdf">アラビア語<span lang="en">Arabic</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
           </li>
           <li>
-            <span class="Btn -disabled" data-href="./document/ToForeignersWhoLiveInJapan_Thai.pdf">タイ語<span lang="en">Thai</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
+            <span class="Btn -disabled" data-href="document/ToForeignersWhoLiveInJapan_Thai.pdf">タイ語<span lang="en">Thai</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
           </li>
           <li>
-            <span class="Btn -disabled" data-href="./document/ToForeignersWhoLiveInJapan_Bengali.pdf">ベンガル語<span lang="en">Bengali</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
+            <span class="Btn -disabled" data-href="document/ToForeignersWhoLiveInJapan_Bengali.pdf">ベンガル語<span lang="en">Bengali</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
           </li>
           <li>
-            <span class="Btn -disabled" data-href="./document/ToForeignersWhoLiveInJapan_Myanmarese.pdf">ミャンマー語<span lang="en">Myanmarese</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
+            <span class="Btn -disabled" data-href="document/ToForeignersWhoLiveInJapan_Myanmarese.pdf">ミャンマー語<span lang="en">Myanmarese</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
           </li>
           <li>
-            <span class="Btn -disabled" data-href="./document/ToForeignersWhoLiveInJapan_Nepali.pdf">ネパール語<span lang="en">Nepali</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
+            <span class="Btn -disabled" data-href="document/ToForeignersWhoLiveInJapan_Nepali.pdf">ネパール語<span lang="en">Nepali</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
           </li>
           <li>
-            <a class="Btn" href="./document/ToForeignersWhoLiveInJapan_Khmer.pdf">クメール語<span lang="en">Khmer</span></a>
+            <a class="Btn" href="document/ToForeignersWhoLiveInJapan_Khmer.pdf">クメール語<span lang="en">Khmer</span></a>
           </li>
           <li>
-            <span class="Btn -disabled" data-href="./document/ToForeignersWhoLiveInJapan_Lao.pdf">ラオス語<span lang="en">Lao</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
+            <span class="Btn -disabled" data-href="document/ToForeignersWhoLiveInJapan_Lao.pdf">ラオス語<span lang="en">Lao</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
           </li>
           <li>
-            <span class="Btn -disabled" data-href="./document/ToForeignersWhoLiveInJapan_Mongolian.pdf">モンゴル語<span lang="en">Mongolian</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
+            <span class="Btn -disabled" data-href="document/ToForeignersWhoLiveInJapan_Mongolian.pdf">モンゴル語<span lang="en">Mongolian</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
           </li>
           <li>
-            <span class="Btn -disabled" data-href="./document/ToForeignersWhoLiveInJapan_Tagalog.pdf">タガログ語<span lang="en">Tagalog</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
+            <span class="Btn -disabled" data-href="document/ToForeignersWhoLiveInJapan_Tagalog.pdf">タガログ語<span lang="en">Tagalog</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
           </li>
           <li>
-            <span class="Btn -disabled" data-href="./document/ToForeignersWhoLiveInJapan_Vietnamese.pdf">ベトナム語<span lang="en">Vietnamese</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
+            <span class="Btn -disabled" data-href="document/ToForeignersWhoLiveInJapan_Vietnamese.pdf">ベトナム語<span lang="en">Vietnamese</span><span class="VisuallyHidden">版は現在準備中です。</span></span>
           </li>
         </ul>
       </section>

--- a/src/index.njk
+++ b/src/index.njk
@@ -264,8 +264,12 @@ date: Last Modified
         <p>疑義や誤りのご指摘などは、<a href="mailto:info@polaar.jp">info@polaar.jp</a> カワセタケヒロ宛にお問い合せください。（個人での対応となりますので、すべてに対応できない可能性があります。あらかじめご了承ください）</p>
       </section>
     </article>
+
     <footer id="Footer">
-      <h2 class="VisuallyHidden">ライセンス</h2>
+      <header class="VisuallyHidden">
+        <h2>ライセンス</h2>
+        <a href="#Footer">このセクションへのリンク</span></a>
+      </header>
       <p class="License">
         <a href="https://covid-19-act.jp">covid-19-act.jp</a>
         <svg role="img" width="18" height="18" viewBox="0 0 18 18" fill="none" aria-labelledby="title-CC">

--- a/src/index.njk
+++ b/src/index.njk
@@ -73,7 +73,7 @@ date: Last Modified
       <section class="Section -hasSeparator" id="For-what">
         <header class="HeadingAnchor">
           <h2>入口に「入れません」と<br/>表示するポスター</h2>
-          <a href="#For-what"><span class="VisuallyHidden">このセクションへのリンク</span></a>
+          <a href="#For-what"><span class="VisuallyHidden">このセクションへのリンク</a>
         </header>
         <p>熱発症状がみられる方に対して、院内に入ることができない旨と、東京都や日本医師会が設置している相談窓口への電話を促すポスターです。病院の方針として熱発患者を受け入れていたり、感染症外来などを設置している場合は、「入り口から病院の中のスタッフを呼んでもらう」をご活用ください。</p>
         <ul class="ColumnList">

--- a/src/index.njk
+++ b/src/index.njk
@@ -9,7 +9,7 @@ date: Last Modified
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Act Against COVID-19 - 医療機関用ツール</title>
-    <script type="text/javascript" src="//webfont.fontplus.jp/accessor/script/fontplus.js?owI8-d2e8Dw%3D&amp;box=wzsij36dhRc%3D&amp;timeout=5&amp;aa=1&amp;ab=2" charset="utf-8"></script>
+    <script src="//webfont.fontplus.jp/accessor/script/fontplus.js?owI8-d2e8Dw%3D&amp;box=wzsij36dhRc%3D&amp;timeout=5&amp;aa=1&amp;ab=2"></script>
     <link rel="stylesheet" href="style.css">
     <meta name="description" content="19が疑われる方についての対応方針を伝えるためのコミュニケーションツールです。あなたの病院の方針に合ったツールを選んでご活用ください。">
     <meta property="og:title" content="Act Against COVID-19 - 医療機関用ツール">

--- a/src/index.njk
+++ b/src/index.njk
@@ -267,10 +267,8 @@ date: Last Modified
     </article>
 
     <footer id="Footer">
-      <header class="VisuallyHidden">
-        <h2>ライセンス</h2>
-        <a href="#Footer">このセクションへのリンク</span></a>
-      </header>
+      <h2 class="VisuallyHidden">ライセンス</h2>
+      <a class="VisuallyHidden" href="#Footer">このセクションへのリンク</a>
       <p class="License">
         <a href="https://covid-19-act.jp">covid-19-act.jp</a>
         <svg role="img" width="18" height="18" viewBox="0 0 18 18" fill="none" aria-labelledby="title-CC">

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -178,7 +178,7 @@ ul ul {
   width: 24px;
   height: 24px;
   line-height: inherit;
-  background-image: url(./image/link.svg);
+  background-image: url(image/link.svg);
   background-repeat: no-repeat;
   background-position: center center;
 }
@@ -320,7 +320,7 @@ ul ul {
   width: 16px;
   height: 20px;
   line-height: inherit;
-  background-image: url(./image/pdf.svg);
+  background-image: url(image/pdf.svg);
   background-repeat: no-repeat;
   background-position: center center;
 }


### PR DESCRIPTION
Netlify は URLの末尾スラッシュがなくてもスラッシュありのURLにデフォルトでRewriteしているが、このせいでドキュメント内の相対パスが意図通りに機能しない。

`https://hoge.com/follow` のページ内で `./image/hoge.jpg` があると `https://hoge.com/image/hoge.jpg` を読み込もうとし、リンク切れを起こしていた。

| リンク切れの様子 |
| :---: |
| ![スクリーンショット 2020-04-21 12 05 41](https://user-images.githubusercontent.com/710216/79821123-e6607380-83c8-11ea-860c-8516966db8f0.png) |

これを `<base href="https://hoge.com/follow/">` を用いて対応する。

`yarn dev` で開発中は `<base>` 要素を出力しないように設定した。